### PR TITLE
chore: configured action to run using node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: ""
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 branding:
   icon: "type"


### PR DESCRIPTION
## 🤔 Why ?

Github Actions are transitioning from Node 16 to Node 20
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20

A warning is now displayed for any action using Node 16

## 💻 How ?

Updated `action.yml` configuration following instructions from 
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/#what-you-need-to-do
https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions

## ✅ How to validate this PR ?

Not sure yet...
